### PR TITLE
Create a nubis user on base ami

### DIFF
--- a/nubis/Puppetfile
+++ b/nubis/Puppetfile
@@ -81,3 +81,5 @@ mod 'thias/sysctl', '1.0.2'
 mod 'maestrodev/wget', '1.7.0'
 
 mod 'elasticsearch/elasticsearch', '0.9.6'
+
+mod 'saz/sudo', '3.0.9'

--- a/nubis/puppet/init.pp
+++ b/nubis/puppet/init.pp
@@ -8,6 +8,7 @@ import 'jq.pp'
 import 'postfix.pp'
 import 'datadog.pp'
 import 'mig.pp'
+import 'user.pp'
 
 # Simple node liveness check
 include nubis_discovery

--- a/nubis/puppet/user.pp
+++ b/nubis/puppet/user.pp
@@ -11,3 +11,12 @@ user { 'nubis':
     shell   => '/bin/bash',
     require => Group['nubis'],
 }
+
+file { '/etc/sudoers.d/nubis-sudoers':
+    ensure  => file,
+    owner   => root,
+    group   => root,
+    mode    => 0440,
+    content => "nubis   ALL=(ALL)   NOPASSWD:ALL\n",
+    require => [ User['nubis'], Group['nubis'] ],
+}

--- a/nubis/puppet/user.pp
+++ b/nubis/puppet/user.pp
@@ -1,0 +1,13 @@
+# create nubis user on the base image
+
+group { 'nubis':
+    ensure => present,
+}
+
+user { 'nubis':
+    ensure  => present,
+    groups  => [ 'nubis' ],
+    home    => '/home/nubis',
+    shell   => '/bin/bash',
+    require => Group['nubis'],
+}

--- a/nubis/puppet/user.pp
+++ b/nubis/puppet/user.pp
@@ -12,11 +12,12 @@ user { 'nubis':
     require => Group['nubis'],
 }
 
-file { '/etc/sudoers.d/nubis-sudoers':
-    ensure  => file,
-    owner   => root,
-    group   => root,
-    mode    => 0440,
-    content => "nubis   ALL=(ALL)   NOPASSWD:ALL\n",
-    require => [ User['nubis'], Group['nubis'] ],
+class { 'sudo':
+  purge               => false,
+  config_file_replace => false,
+}
+
+sudo::conf { 'nubis':
+  content  => "nubis ALL=(ALL) NOPASSWD: ALL",
+  require => [ User['nubis'], Group['nubis'] ],
 }


### PR DESCRIPTION
Creates a nubis user on the base ami and also adds it to the sudoers file. At this moment there is no method of actually getting pubkeys to the host. I suggest that we do it with packer and actually load the list of pubkeys we want when building the package