### PR TITLE
Ubuntu repositories have very old versions of the ec2-ami-tools that just don't work at all.

### DIFF
--- a/nubis/bin/packer-bootstrap
+++ b/nubis/bin/packer-bootstrap
@@ -19,8 +19,15 @@ if [[ -f /etc/debian_version ]]; then
    # this is required for packer, and feels like a better spot to do it instead of in nubis-puppet.
    sudo -E apt-add-repository multiverse
    sudo -E apt-get -y update
-   sudo -E apt-get -y install ec2-ami-tools
+
+   # These are dependencies for ec2-ami-tools
+   sudo -E apt-get -y install grub kpartx unzip
    sudo -E apt-add-repository -r multiverse
+
+   # Grab them from Amazon itself, as the ones in the Ubuntu repos are too *old*
+   wget -O /tmp/ec2-ami-tools-1.5.7.zip http://s3.amazonaws.com/ec2-downloads/ec2-ami-tools-1.5.7.zip
+   ( cd /tmp && unzip /tmp/ec2-ami-tools-1.5.7.zip )
+   sudo -E rsync -av /tmp/ec2-ami-tools-1.5.7/{bin,etc,lib} /usr/local/
 
    # After removing multiverse we need to rebuild the indexes, since this won't happen on their own,
    # apparently.


### PR DESCRIPTION
This manually grabs latest version from Amazon