### PR TITLE
Add support for CONSUL_ACL_TOKEN in bootstrap.

### DIFF
--- a/nubis/bin/consul-autojoin.sh
+++ b/nubis/bin/consul-autojoin.sh
@@ -87,6 +87,16 @@ cat <<EOF | tee /etc/consul/zzz-acl.json
 EOF
 fi
 
+# Discover our ACL token (needs moving to nubis-consul)
+if [ "$CONSUL_ACL_TOKEN" ]; then
+
+cat <<EOF | tee /etc/consul/zzz-acl-token.json
+{
+  "acl_token": "$CONSUL_ACL_TOKEN",
+}
+EOF
+fi
+
 # Auto-discover certificate and key
 curl -f -s -o /etc/consul/consul.pem $CONSUL_UI/v1/kv/environments/$NUBIS_ENVIRONMENT/global/consul/cert?raw
 curl -f -s -o /etc/consul/consul.key $CONSUL_UI/v1/kv/environments/$NUBIS_ENVIRONMENT/global/consul/key?raw


### PR DESCRIPTION
If passed to the instance via user-data, will be used by default by
Consul

Helps along nubisproject/nubis-consul#26