### PR TITLE
consul-do permission fix

### DIFF
--- a/nubis/puppet/consul.pp
+++ b/nubis/puppet/consul.pp
@@ -69,6 +69,13 @@ class consul_do (
       verbose => true,
       redownload => true, # The file already exists, we replace it
   } ->
+  file { "/usr/local/bin/consul-do-${version}":
+      ensure  => file,
+      owner   => root,
+      group   => root,
+      mode    => '0755',
+      require => Wget::Fetch["download consul-do $version"]
+  } ->
   file { "/usr/local/bin/consul-do":
     ensure => "link",
     target => "/usr/local/bin/consul-do-$version",

--- a/nubis/puppet/consul.pp
+++ b/nubis/puppet/consul.pp
@@ -74,7 +74,6 @@ class consul_do (
       owner   => root,
       group   => root,
       mode    => '0755',
-      require => Wget::Fetch["download consul-do $version"]
   } ->
   file { "/usr/local/bin/consul-do":
     ensure => "link",


### PR DESCRIPTION
This commit will fix the permission when consul-do gets installed, `wget` fetches it with mode `0644`, we should at least make sure that it gets `0755` so that users can call this utility