### PR TITLE
Extra comma causes consul to not startup

### DIFF
--- a/nubis/bin/consul-autojoin.sh
+++ b/nubis/bin/consul-autojoin.sh
@@ -92,7 +92,7 @@ if [ "$CONSUL_ACL_TOKEN" ]; then
 
 cat <<EOF | tee /etc/consul/zzz-acl-token.json
 {
-  "acl_token": "$CONSUL_ACL_TOKEN",
+  "acl_token": "$CONSUL_ACL_TOKEN"
 }
 EOF
 fi


### PR DESCRIPTION
The extra comma causes consul to not startup properly and thus causing consul and confd to fail