### PR TITLE
There is no reason to have dnsmasq bind on anything beside loopback

### DIFF
--- a/nubis/puppet/dnsmasq.pp
+++ b/nubis/puppet/dnsmasq.pp
@@ -1,4 +1,5 @@
 class { 'dnsmasq':
+  interface         => 'lo',
 }
 
 dnsmasq::dnsserver { 'consul':


### PR DESCRIPTION
And this causes issues with the akamai-dns project, that's trying to
be a DNS service

Fixes #205