### PR TITLE
Adjust puppet directory permissions

### DIFF
--- a/nubis/bin/packer-bootstrap
+++ b/nubis/bin/packer-bootstrap
@@ -97,7 +97,7 @@ if [[ -f /tmp/librarian-puppet.tar.gz ]]; then
    # We're probably going to have secrets at some point. I use chown 0:0 to avoid having to figure out
    # whether root's group is root, or wheel.
    sudo chown -R 0:0 /etc/puppet
-   sudo chmod 700 /etc/puppet
+   sudo chmod 755 /etc/puppet
 
    # Configure a local fileserver, accessible in puppet with puppet:///nubis/somefile
    sudo mkdir -p /etc/nubis/puppet/{files,templates}


### PR DESCRIPTION
There is no need to be this restrictive here. We store no secrets here.