### PR TITLE
Remove nubis-puppet-eip since this is used on a case by case basis

### DIFF
--- a/nubis/Puppetfile
+++ b/nubis/Puppetfile
@@ -54,10 +54,6 @@ mod 'nubis/nubis_storage',
     :git => 'https://github.com/Nubisproject/nubis-puppet-storage.git',
     :ref => 'v1.0.0'
 
-mod 'nubis/nubis_eip',
-    :git => 'https://github.com/Nubisproject/nubis-puppet-eip.git',
-    :ref => 'v1.0.1'
-
 # This developer doesn't tag his releases on github
 # https://github.com/maxchk/puppet-varnish/pull/57
 # https://github.com/maxchk/puppet-varnish/pull/60


### PR DESCRIPTION
Related to issue #209 