### PR TITLE
Add proxy configuration to base

### DIFF
--- a/nubis/puppet/files/profile.d_proxy.sh
+++ b/nubis/puppet/files/profile.d_proxy.sh
@@ -1,0 +1,10 @@
+TEST=$(host proxy.service.consul)
+RV=$?
+if [ ${RV} == 0 ]; then
+    export http_proxy="http://proxy.service.consul:3128/"
+    export https_proxy="http://proxy.service.consul:3128/"
+    export no_proxy="localhost,127.0.0.1,.localdomain,10.0.0.0/8"
+    export HTTP_PROXY="$http_proxy"
+    export HTTPS_PROXY="$https_proxy"
+    export NO_PROXY="$no_proxy"
+fi

--- a/nubis/puppet/init.pp
+++ b/nubis/puppet/init.pp
@@ -11,6 +11,7 @@ import 'mig.pp'
 import 'credstash.pp'
 import 'consulate.pp'
 import 'nubis_lib.pp'
+import 'proxy.pp'
 
 # Simple node liveness check
 include nubis_discovery

--- a/nubis/puppet/proxy.pp
+++ b/nubis/puppet/proxy.pp
@@ -1,0 +1,10 @@
+# Install default proxy configuration file.
+
+file {
+    '/etc/profile.d/proxy.sh':
+        ensure  => present,
+        mode    => '0644',
+        owner   => 'root',
+        group   => 'root',
+        source  => 'puppet:///nubis/files/profile.d_proxy.sh',
+}


### PR DESCRIPTION
Logs from the proxy in nubis-lab:

Tested from amazon-linux:
1446155606.088     58 10.162.2.181 TCP_MISS/200 19829 GET http://www.google.com/ - DIRECT/173.194.121.16 text/html

Tested from Ubuntu:
1446156000.226     27 10.162.2.110 TCP_MISS/404 1918 GET http://www.google.com/404 - DIRECT/173.194.121.18 text/html