### PR TITLE
nubis-lib cleanup

### DIFF
--- a/nubis/puppet/files/nubis-lib.sh
+++ b/nubis/puppet/files/nubis-lib.sh
@@ -96,13 +96,6 @@ function get_instance_ip() {
     echo "${instance_ip}"
 }
 
-# Gets instance IP, doesn't take into account eni that is attached
-# usage: get_instance_ip
-function get_instance_ip() {
-    local instance_ip=$(curl --retry 3 --retry-delay 0 -s -fq http://169.254.169.254/latest/meta-data/local-ipv4)
-    echo "${instance_ip}"
-}
-
 # Send message to log
 # usage: log migrate "This is a log message"
 function log {


### PR DESCRIPTION
Cleanup nubis-lib in this PR we are doing the following

1. Moving top level variables that we populate via the aws metadata service to its own function
2. Added some functions that ease how we grab some commonly used values such as instance-id, eni-id etc etc
3. Cleanup log function to be more generic
4. Added a `die()` function
5. Remove the pre-req check, we assume that its there since it gets installed in base