### PR TITLE
Upgrade and cleanup our puppet modules

### DIFF
--- a/nubis/Puppetfile
+++ b/nubis/Puppetfile
@@ -5,24 +5,27 @@ forge "https://forgeapi.puppetlabs.com"
 ##########################################################
 
 # modules from the puppet forge
-mod 'puppetlabs/stdlib', '4.7.0'
-mod 'puppetlabs/mysql', '3.5.0'
+mod 'puppetlabs/stdlib', '4.11.0'
+mod 'puppetlabs/mysql', '3.6.2'
 
 mod 'puppetlabs/concat', '1.2.4'
 
-mod 'puppetlabs/apache', '1.6.0'
+mod 'puppetlabs/apache', '1.8.0'
 
-mod 'puppetlabs/rabbitmq', '5.2.3'
-mod 'puppetlabs/vcsrepo', '1.3.1'
+# 2.x is out, but it causes strange apt update race conditions in fluentd+datadog
+mod 'puppetlabs/apt', '1.8.0'
+
+mod 'puppetlabs/rabbitmq', '5.3.1'
+mod 'puppetlabs/vcsrepo', '1.3.2'
 mod 'jfryman/nginx', '0.2.7'
 
-mod 'ajcrowe/supervisord', '0.5.2'
+mod 'ajcrowe/supervisord', '0.6.0'
 mod 'torrancew/cron', '0.1.0'
 mod 'jbeard/nfs', '0.2.1'
 
-mod 'stankevich/python', '1.9.6'
+mod 'stankevich/python', '1.11.0'
 
-mod 'KyleAnderson/consul', '1.0.4'
+mod 'KyleAnderson/consul', '1.0.5'
 
 # gozer's fork has minimal upstart support, upstream doesn't
 mod 'gozer/puppet-confd',
@@ -31,7 +34,8 @@ mod 'gozer/puppet-confd',
 
 # Skeleton to get above confd happy
 mod 'nubis-confd_site',
-    :git => 'https://github.com/gozer/nubis-site_confd.git'
+    :git => 'https://github.com/gozer/nubis-site_confd.git',
+    :ref => '0.1.1'
 
 mod 'srf/fluentd', '0.1.4'
 mod 'mjhas/postfix', '1.0.0'
@@ -40,7 +44,7 @@ mod 'mjhas/postfix', '1.0.0'
 mod 'bhourigan/dnsmasq',
     :git => 'https://github.com/bhourigan/puppet-dnsmasq.git'
 
-mod 'datadog/datadog_agent', '1.3.0'
+mod 'datadog/datadog_agent', '1.6.0'
 
 mod 'nubis/nubis_discovery',
     :git => 'https://github.com/Nubisproject/nubis-puppet-discovery.git',
@@ -66,13 +70,7 @@ mod 'maxchk/varnish',
     :git => 'https://github.com/gozer/puppet-varnish.git',
     :ref => 'nubis'
 
-mod 'puppetlabs/firewall', '1.7.0'
-mod 'thias/sysctl', '1.0.2'
+mod 'puppetlabs/firewall', '1.7.2'
+mod 'thias/sysctl', '1.0.4'
 
-mod 'maestrodev/wget', '1.7.0'
-
-mod 'elasticsearch/elasticsearch', '0.9.8'
-
-mod 'thejandroman/kibana3', '0.0.4'
-
-mod 'meltwater/cpan', '1.0.1'
+mod 'maestrodev/wget', '1.7.1'


### PR DESCRIPTION
Many upgrades, some cleanup removal, and 2 left pinned modules:
 - puppetlabs-apt (2.x breaks apt-get update with fluentd + datadog)
 - puppetlabs-concat (2.x breaks some of our modules, explicitely requesting < 2.x)

Fixes #272 and #209