### PR TITLE
Move package puppet resource generation into houskeeper script, so it gets run at the end of every build, not just base.

### DIFF
--- a/nubis/bin/packer-bootstrap
+++ b/nubis/bin/packer-bootstrap
@@ -107,6 +107,3 @@ sudo bash -c 'cat > /etc/puppet/fileserver.conf' << EOF
     path /etc/nubis/puppet
     allow *
 EOF
-
-# Document the installed version of packages for forensic analysis later, if needed.
-puppet resource package | sudo tee -a /etc/puppet/package-versions.pp >/dev/null

--- a/nubis/puppet/files/housekeeper
+++ b/nubis/puppet/files/housekeeper
@@ -31,3 +31,10 @@ sudo rm -f /var/spool/mail/*
 # Remove nubis cache
 sudo rm -f /var/cache/nubis/*
 
+# Document the installed version of packages for forensic analysis later, if needed.
+puppet resource package | sudo tee /etc/puppet/package-versions.pp >/dev/null
+
+PROJECT_NAME=$1
+if [ "$PROJECT_NAME" != "" ]; then
+  puppet resource package | sudo tee /etc/puppet/$PROJECT_NAME-package-versions.pp >/dev/null
+fi


### PR DESCRIPTION
Fixes #358