### PR TITLE
Disable NFS related services on Amazon Linux (rpcbind & nfslock)

### DIFF
--- a/nubis/puppet/nfs-disable.pp
+++ b/nubis/puppet/nfs-disable.pp
@@ -1,0 +1,12 @@
+# Disable NFS related services
+
+if $osfamily == 'RedHat' {
+  service { 'rpcbind':
+    enable => false,
+    ensure => 'stopped',
+  }
+  service { 'nfslock':
+    enable => false,
+    ensure => 'stopped',
+  }
+}


### PR DESCRIPTION
Fixes #361