### PR TITLE
Work around problem with fluent-plugin-ec2-metadata on Ubuntu.

### DIFF
--- a/nubis/puppet/fluentd.pp
+++ b/nubis/puppet/fluentd.pp
@@ -36,11 +36,32 @@ else {
 # For the ec2 plugin
 package { [$ruby_dev, "make", "gcc"]:
   ensure => "present",
-}->
-fluentd::install_plugin { 'ec2-metadata':
-  plugin_type => 'gem',
-  plugin_name => 'fluent-plugin-ec2-metadata',
-  ensure      => '0.0.7',
+}
+
+if $osfamily == 'Debian' {
+  # Needed until https://github.com/takus/fluent-plugin-ec2-metadata/pull/17 lands
+  package { "fluent-plugin-ec2-metadata":
+    ensure   => "0.0.10",
+    provider => "fluentgem",
+    source   => "http://people.mozilla.org/~pchiasson/ruby",
+    require     => [
+      Package["make"],
+      Package["gcc"],
+      Package[$ruby_dev],
+    ],
+  }
+}
+else {
+  fluentd::install_plugin { 'ec2-metadata':
+    plugin_type => 'gem',
+    plugin_name => 'fluent-plugin-ec2-metadata',
+    ensure      => '0.0.10',
+    require     => [
+      Package["make"],
+      Package["gcc"],
+      Package[$ruby_dev],
+    ],
+  }
 }
 
 fluentd::configfile { 'syslog': }


### PR DESCRIPTION
Right now, latest version of fluent-plugin-ec2-metadata requires just any
version of the fluentd gem. The latest versions of which ( 0.14.x ) now
require ruby > 2.0, which, unfortunately, isn't compatible with fluentd
on Ubuntu.

So, the correct solution would be to follow the 0.12.x branch of the
fluentd plugin.

Submitted takus/fluent-plugin-ec2-metadata#17 upstream

In the meantime, I've made a copy of the gem with just a clearer
set of requirements to use.