### PR TITLE
Move node_exporter restart script somewhere always executable

### DIFF
--- a/nubis/files/confd/node_exporter.toml
+++ b/nubis/files/confd/node_exporter.toml
@@ -1,6 +1,6 @@
 [template]
 src = "node_exporter.tmpl"
-dest = "/var/run/node_exporter"
+dest = "/usr/local/sbin/nubis_node_exporter"
 prefix = "/environments/%%ENVIRONMENT%%/global/node_exporter"
 
 uid = 0
@@ -11,4 +11,4 @@ keys = [
     "/config"
 ]
 
-reload_cmd = "/var/run/node_exporter"
+reload_cmd = "/usr/local/sbin/nubis_node_exporter"


### PR DESCRIPTION
From /var/run/node_exporter to /usr/local/sbin/nubis_node_exporter

Fixes #428