### PR TITLE
Enable textfile collector and create static metadata metrics

### DIFF
--- a/nubis/files/confd/node_exporter.tmpl
+++ b/nubis/files/confd/node_exporter.tmpl
@@ -1,8 +1,32 @@
 #!/bin/bash
 
+PROM_DIR=/var/lib/node_exporter/metrics
+
 ENABLED={{ if exists "/config/enabled" }}{{ getv "/config/enabled" }}{{ else }}0{{ end }}
 
 if [ "$ENABLED" == "1" ]; then
+  # Generate fake metrics for Nubis propreties
+  NUBIS_PROJECT=$(nubis-metadata NUBIS_PROJECT)
+  NUBIS_ENVIRONMENT=$(nubis-metadata NUBIS_ENVIRONMENT)
+  NUBIS_ACCOUNT=$(nubis-metadata NUBIS_ACCOUNT)
+  NUBIS_PURPOSE=$(nubis-metadata NUBIS_PURPOSE}
+
+  cat <<EOF > $PROM_DIR/nubis.prom
+nubis{project="$NUBIS_PROJECT",environment="$NUBIS_ENVIRONMENT",account="$NUBIS_ACCOUNT",purpose="$PURPOSE"} 1
+EOF
+
+  # generate fake metrics for AWS propreties
+  INSTANCE_ID=$(curl -fqs http://169.254.169.254/latest/meta-data/instance-id)
+  REGION=$(curl -fqs http://169.254.169.254/latest/dynamic/instance-identity/document | jq '.region' -r)
+  AZ=$(curl -fqs http://169.254.169.254/latest/meta-data/placement/availability-zone)
+  TYPE=$(curl -fqs http://169.254.169.254/latest/meta-data/instance-type)
+  AMI=$(curl -fqs http://169.254.169.254/latest/meta-data/ami-id)
+  INSTANCE=$(curl -fqs http://169.254.169.254/latest/meta-data/instance-id)
+
+  cat <<EOF > $PROM_DIR/aws.prom
+aws{region="$REGION",availability_zone="$AZ",instance_type="$TYPE",ami_id="$AMI",instance_id="$INSTANCE"} 1
+EOF
+
   service node_exporter start
 else
   service node_exporter stop

--- a/nubis/puppet/files/node_exporter.init
+++ b/nubis/puppet/files/node_exporter.init
@@ -20,7 +20,7 @@ export PATH
 
 name=node_exporter
 program="/usr/local/bin/$name"
-args=""
+args="-collector.textfile.directory /var/lib/node_exporter/metrics"
 pidfile=/var/run/$name.pid
 user=root
 group=root

--- a/nubis/puppet/files/node_exporter.upstart
+++ b/nubis/puppet/files/node_exporter.upstart
@@ -10,5 +10,5 @@ setgid root
 script
   exec >> /var/log/node_exporter.log
   exec 2>&1
-  exec /usr/local/bin/node_exporter
+  exec /usr/local/bin/node_exporter -collector.textfile.directory /var/lib/node_exporter/metrics
 end script

--- a/nubis/puppet/node_exporter.pp
+++ b/nubis/puppet/node_exporter.pp
@@ -1,4 +1,4 @@
-$node_exporter_version = "0.12.0rc3"
+$node_exporter_version = "0.12.0"
 $node_exporter_url = "https://github.com/prometheus/node_exporter/releases/download/${node_exporter_version}/node_exporter-${node_exporter_version}.linux-amd64.tar.gz"
 
 notice ("Grabbing node_exporter ${node_exporter_version}")
@@ -8,6 +8,13 @@ staging::file { "node_exporter.${node_exporter_version}.tar.gz":
 staging::extract { "node_exporter.${node_exporter_version}.tar.gz":
   target  => "/usr/local/bin",
   creates => "/usr/local/bin/node_exporter",
+}
+
+file { "/var/lib/node_exporter/metrics":
+  ensure => directory,
+  owner  => root,
+  group  => root,
+  mode   => '0755',
 }
 
 # make sure the services are disabled on boot, confd starts conditionnally later


### PR DESCRIPTION
node_exporter reads metrics from .prom files dropped in /var/lib/node_exporter/metrics

Could be used for all sort of cute custom metrics, but for now, we drop
static (never-changing metadata metrics in there)

aws.prom:
  aws{region="<region>",availability_zone="<az>",instance_type="<type>",ami_id="ami-XXXXXXXX",instance_id="i-XXXX"} 1
nubis.prom:
nubis{project="<project>",environment="<env>",account="<account>",purpose="<purpose>"} 1

Fixes #431

Note, also riding along is an upgrade to 0.12.0 from rc3