### PR TITLE
[tainted] Implement tracking of tainted instances and self-termination

### DIFF
--- a/nubis/Puppetfile
+++ b/nubis/Puppetfile
@@ -90,3 +90,5 @@ mod 'maestrodev/wget', '1.7.3'
 mod 'puppetlabs/ntp', '4.2.0'
 
 mod 'saz/sudo', '3.1.0'
+
+mod 'herculesteam/augeasproviders_pam', '2.1.0'

--- a/nubis/puppet/files/housekeeper
+++ b/nubis/puppet/files/housekeeper
@@ -31,6 +31,9 @@ sudo rm -f /var/spool/mail/*
 # Remove nubis cache
 sudo rm -f /var/cache/nubis/*
 
+# Remove taintededness
+sudo rm -f /.tainted
+
 # Document the installed version of packages for forensic analysis later, if needed.
 puppet resource package | sudo tee /etc/puppet/package-versions.pp >/dev/null
 

--- a/nubis/puppet/files/nubis-taint
+++ b/nubis/puppet/files/nubis-taint
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+if [ "$PAM_TYPE" == "open_session" ]; then
+  if [ ! -r /.tainted ]; then
+    NOW=$(date)
+    HOST=$PAM_RHOST
+    USER=$PAM_USER
+    echo "Instance tainted by $USER from $HOST on $NOW" > /.tainted
+  fi
+fi

--- a/nubis/puppet/files/nubis-taint-reap
+++ b/nubis/puppet/files/nubis-taint-reap
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+PATH=/usr/local/sbin:/usr/local/bin:$PATH
+
+# Are we tainted to start with?
+nubis-tainted
+TAINTED=$?
+
+if [ "$TAINTED" == "0" ]; then
+  exit
+fi
+
+# Is there anybody logged on ?
+LOGGED_ON_USERS=$(w -h | wc -l)
+if [ "$LOGGED_ON_USERS" != 0 ]; then
+  exit
+fi
+
+# Tainted = 1 is just a warning we are tainted
+# Tainted > 1 means we have expired
+if [ "$TAINTED" -gt "1" ]; then
+  NUBIS_ENVIRONMENT=$(nubis-metadata NUBIS_ENVIRONMENT)
+  EXPIRE_FLAG="environments/$NUBIS_ENVIRONMENT/global/delete_tainted"
+  EXPIRE_ENABLED=$(consulate kv get "$EXPIRE_FLAG")
+
+  if [ "$EXPIRE_ENABLED" == "1" ]; then
+    echo "Expiring this instance NOW"
+    echo "NOTIMPLEMENTEDYET: shutdown -p now"
+  else
+    echo "Would have expired this resource, set $EXPIRE_FLAG to enable"
+  fi
+fi

--- a/nubis/puppet/files/nubis-tainted
+++ b/nubis/puppet/files/nubis-tainted
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-PATH=/usr/local/sbin:/usr/local/bin
+PATH=/usr/local/sbin:/usr/local/bin:$PATH
 
 # Are we tainted ?
 if [ ! -r /.tainted ]; then

--- a/nubis/puppet/files/nubis-tainted
+++ b/nubis/puppet/files/nubis-tainted
@@ -2,12 +2,13 @@
 
 PATH=/usr/local/sbin:/usr/local/bin
 
-GRACE="10 sec"
-
 # Are we tainted ?
 if [ ! -r /.tainted ]; then
   exit 0
 fi
+
+# Get this from Consul, possibly ?
+GRACE="1 day"
 
 TAINTED_ON=$(stat -c %z /.tainted)
 EXPIRE_ON=$(date --date "$TAINTED_ON +$GRACE" '+%s')

--- a/nubis/puppet/files/nubis-tainted
+++ b/nubis/puppet/files/nubis-tainted
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+PATH=/usr/local/sbin:/usr/local/bin
+
+GRACE="10 sec"
+
+# Are we tainted ?
+if [ ! -r /.tainted ]; then
+  exit 0
+fi
+
+TAINTED_ON=$(stat -c %z /.tainted)
+EXPIRE_ON=$(date --date "$TAINTED_ON +$GRACE" '+%s')
+UNIX_NOW=$(date '+%s')
+
+if [ "$EXPIRE_ON" -gt "$UNIX_NOW" ]; then
+  echo "Instance is tainted and expires on $(date --date "@$EXPIRE_ON")"
+  # Warning
+  STATUS=1
+else
+  echo "Instance is tainted and has expired since $(date --date "@$EXPIRE_ON")"
+  # error
+  STATUS=2
+fi
+
+cat /.tainted
+
+exit $STATUS

--- a/nubis/puppet/files/sshrc
+++ b/nubis/puppet/files/sshrc
@@ -1,8 +1,5 @@
-#!/bin/bash
-
-# Bail when no terminal
-if [ "$SSH_TTY" == "" ]; then
- exit
+# Only check taintedness if we are a terminal
+if [ ! -z "$SSH_TTY" ]; then
+  /usr/local/bin/nubis-tainted
 fi
 
-/usr/local/bin/nubis-tainted

--- a/nubis/puppet/files/sshrc
+++ b/nubis/puppet/files/sshrc
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Bail when no terminal
+if [ "$SSH_TTY" == "" ]; then
+ exit
+fi
+
+/usr/local/bin/nubis-tainted

--- a/nubis/puppet/files/svc-tainted.json
+++ b/nubis/puppet/files/svc-tainted.json
@@ -1,0 +1,11 @@
+{
+  "service": {
+    "name": "tainted",
+
+    "check": {
+      "notes": "Check to determine if a node is tainted, and if it has expired its grace period",
+      "script": "/usr/local/bin/nubis-tainted",
+      "interval": "30m"
+    }
+  }
+}

--- a/nubis/puppet/taint.pp
+++ b/nubis/puppet/taint.pp
@@ -1,0 +1,60 @@
+# PAM hook to invoke our utility on ssh logins and taint the instance
+pam { "Set PAM sshd to taint resources":
+  ensure    => present,
+  service   => 'sshd',
+  type      => 'session',
+  control   => 'optional',
+  module    => 'pam_exec.so',
+  arguments => ["log=/var/log/tainted.log", "/usr/local/sbin/nubis-taint"],
+}
+
+# Wrapper to actually perform the tainting
+file {"/usr/local/sbin/nubis-taint":
+ ensure => file,
+ owner  => root,
+ group  => root,
+ mode   => '0755',
+ source => 'puppet:///nubis/files/nubis-taint',
+}
+
+# Util script to check if we are tainted
+file {"/usr/local/bin/nubis-tainted":
+ ensure => file,
+ owner  => root,
+ group  => root,
+ mode   => '0755',
+ source => 'puppet:///nubis/files/nubis-tainted',
+}
+
+# Utility to self-terminate tainted instance
+file {"/usr/local/sbin/nubis-taint-reap":
+ ensure => file,
+ owner  => root,
+ group  => root,
+ mode   => '0755',
+ source => 'puppet:///nubis/files/nubis-taint-reap',
+}
+
+# Warning on ssh login about taintedness
+file {"/etc/ssh/sshrc":
+ ensure => file,
+ owner  => root,
+ group  => root,
+ mode   => '0755',
+ source => 'puppet:///nubis/files/sshrc',
+}
+
+cron::hourly {
+  'nubis-taint-reap':
+    user        => 'root',
+    command     => '/usr/local/sbin/nubis-taint-reap',
+}
+
+file { "/etc/consul/svc-tainted.json":
+ ensure => file,
+ owner  => root,
+ group  => root,
+ mode   => '0644',
+ source => 'puppet:///nubis/files/svc-tainted.json',
+ require => Class['consul'],
+}


### PR DESCRIPTION
Implement tracking of tainted instances and self-termination

First initial implementation, consisting of:
  * ssh PAM.d session hook to invoke /usr/local/sbin/nubis-taint
  * /usr/local/sbin/nubis-taint PAM helper to just mark an instance as tainted on ssh logins
  * /.tainted as a flag file indicating an instance has been tainted
  * /usr/local/bin/nubis-tainted to check on taintedness (don't ever look for /.tainted yourself )
  * /etc/consul/svc-tainted.json to expose to consul tainted nodes's status
  * /usr/local/sbin/nubis-taint-reap to self-terminate if:
    * we are tainted
    * we are old enough ( 2 day grace period for now )
    * nobody is currently logged-in
    * [consul] environments/$NUBIS_ENVIRONMENT/global/delete_tainted feature enable flag (off by default)
  * hourly /usr/local/sbin/nubis-taint-reap invocation

NOTE: currently, the actual shutdown invocation is commented out on purpose for testing purposes before we start destroying the world