### PR TITLE
[metadata] Make sure non-root users can use nubis-metadata correctly

### DIFF
--- a/nubis/puppet/files/nubis-metadata
+++ b/nubis/puppet/files/nubis-metadata
@@ -10,6 +10,21 @@ fi
 curl --retry 5 -fqs -z $USERDATA_FILE -o $USERDATA_FILE http://169.254.169.254/latest/user-data
 
 CURL_RV=$?
+
+# If we can't write to the userdata file and we aren't root
+# use a possibly outdated one or retry using a cache in our
+# own home
+# CURLE_WRITE_ERROR (23)
+if [ "$CURL_RV" == "23" ] && [ "$(id -u)" != "0" ]; then
+  # Use the possibly outdated userdata file if we can read it
+  if [ -r "$USERDATA_FILE" ]; then
+    CURL_RV=0
+  else
+    USERDATA_FILE=~/.nubis-metadata
+    curl --retry 5 -fqs -z $USERDATA_FILE -o $USERDATA_FILE http://169.254.169.254/latest/user-data
+    CURL_RV=$?
+fi
+
 if [ "$CURL_RV" != "0" ]; then
   echo "ERROR: curl failed! ($CURL_RV)"
   exit $CURL_RV


### PR DESCRIPTION
Either using a stale version of the system's cache, or failing that,
caching their own version of it.

This was discovered with nubis-tainted

Fixes #449