### PR TITLE
Add initial working skeleton for running serverspec tests during AMI build

### DIFF
--- a/nubis/builder/tests.json
+++ b/nubis/builder/tests.json
@@ -1,0 +1,16 @@
+{
+  "provisioners": [
+  {
+    "type": "file",
+    "source": "nubis/tests",
+    "destination": "/tmp",
+    "order": "100"
+  },
+  {
+    "type": "shell",
+    "script": "nubis/tests/run-tests",
+    "except" : [ "amazon-ebs-ubuntu" ],
+    "order": "101"
+  }
+  ]
+}

--- a/nubis/tests/Gemfile
+++ b/nubis/tests/Gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gem "rake"
+gem "serverspec"
+gem "json"

--- a/nubis/tests/Rakefile
+++ b/nubis/tests/Rakefile
@@ -1,0 +1,9 @@
+require 'rake'
+require 'rspec/core/rake_task'
+
+task :default => :spec
+
+RSpec::Core::RakeTask.new(:spec) do |t|
+  t.pattern = 'spec/*_spec.rb'
+end
+

--- a/nubis/tests/run-tests
+++ b/nubis/tests/run-tests
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Be explicitly all-inclusive in our PATH, just to be safe
+export PATH="$HOME/bin:$(ruby -e 'puts Gem.user_dir')/bin:$PATH:/usr/local/sbin:/usr/sbin:/sbin"
+
+cd /tmp/tests
+
+gem install bundler --no-ri --no-rdoc --user-install
+
+# This is an optionnal (but good) dependency of bundler
+gem install io-console --no-ri --no-rdoc --user-install
+
+# Install serverspec and what it needs
+bundle install --path=vendor
+
+# Run spec tests
+bundle exec rake spec
+
+STATUS=$?
+
+# Cleanup after ourselves
+rm -rf /tmp/tests
+
+# Bubble up serverspec's results
+exit $STATUS

--- a/nubis/tests/spec/services_spec.rb
+++ b/nubis/tests/spec/services_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+# These shouldn't be enabled, our own startup logic starts it up
+describe service('consul') do
+  it { should_not be_enabled }
+end
+
+# These should be enabled
+describe service('confd') do
+  it { should be_enabled }
+end
+
+describe service('td-agent') do
+  it { should be_enabled }
+end
+
+describe service('ntpd') do
+  it { should be_enabled }
+end

--- a/nubis/tests/spec/spec_helper.rb
+++ b/nubis/tests/spec/spec_helper.rb
@@ -1,0 +1,4 @@
+require 'serverspec'
+
+set :backend, :exec
+

--- a/nubis/tests/spec/timezone_spec.rb
+++ b/nubis/tests/spec/timezone_spec.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+
+# Timezone should be set to UTC
+describe command('cmp /etc/localtime /usr/share/zoneinfo/UTC') do
+  its(:exit_status) { should eq 0 }
+end

--- a/nubis/tests/spec/users_spec.rb
+++ b/nubis/tests/spec/users_spec.rb
@@ -1,0 +1,14 @@
+describe user('centos') , :if => os[:family] == 'redhat' do
+  it { should exist }
+  it { should belong_to_group 'wheel' }
+end
+
+describe user('ec2-user') , :if => os[:family] == 'amazon' do
+  it { should exist }
+  it { should belong_to_group 'wheel' }
+end
+
+describe user('ubuntu') , :if => os[:family] == 'ubuntu' do
+  it { should exist }
+  it { should belong_to_group 'sudo' }
+end


### PR DESCRIPTION
This has just some simple sample tests, nothing major, but they all should pass

Road for implementing more tests is ahead.

Also, eventually, probably worth moving some of this logic into nubis-builder
itself, to simplify the required scaffolding

Fixes #133