### PR TITLE
Don't run the datadog agent when its disabled

### DIFF
--- a/nubis/puppet/files/datadog-discover
+++ b/nubis/puppet/files/datadog-discover
@@ -6,8 +6,15 @@ declare api_key
 # shellcheck disable=SC1091
 source /etc/nubis-config/datadog.sh
 
+# Is DataDog disabled ?
+if [[ "$api_key" == *"DISABLED"* ]]; then
+  /etc/init.d/datadog-agent stop
+else
+
 # fix the config file (poor-man's Augeas)
 perl -pi -e"s/^api_key: (.*)/api_key: $api_key/g" /etc/dd-agent/datadog.conf
 
 # Restart datadog is all is well
 /etc/init.d/datadog-agent configtest && /etc/init.d/datadog-agent restart
+
+fi


### PR DESCRIPTION
Heuristics a bit:

When the Datadog API keys contains 'DISABLED', don't bother running it

It chews up lots of CPU and is very log-noisy when its API key is invalid

Fixes #496