### PR TITLE
Include more information in each forwarded log event

### DIFF
--- a/nubis/puppet/files/fluentd.sysconfig
+++ b/nubis/puppet/files/fluentd.sysconfig
@@ -4,3 +4,15 @@ if [ -r /etc/profile.d/proxy.sh ]; then
 fi
 
 TD_AGENT_USER="root"
+
+# Expose our project to fluentd
+NUBIS_PROJECT=$(nubis-metadata NUBIS_PROJECT)
+export NUBIS_PROJECT
+
+# Expose our purpose to fluentd
+NUBIS_PURPOSE=$(nubis-metadata NUBIS_PURPOSE)
+export NUBIS_PURPOSE
+
+#Expose our stack to fluentd
+NUBIS_STACK=$(nubis-metadata NUBIS_STACK)
+export NUBIS_STACK

--- a/nubis/puppet/fluentd.pp
+++ b/nubis/puppet/fluentd.pp
@@ -102,6 +102,14 @@ file { '/etc/td-agent/config.d/ec2_metadata.conf':
         instance_type ${instance_type}
         az            ${availability_zone}
         region        ${region}
+        vpc_id        ${vpc_id}
+        subnet_id     ${subnet_id}
+        private_ip    ${private_ip}
+        ami_id        ${image_id}
+        mac           ${mac}
+        project       "#{ENV[\'NUBIS_PROJECT\']}"
+        stack         "#{ENV[\'NUBIS_STACK\']}"
+        purpose       "#{ENV[\'NUBIS_PURPOSE\']}"
       </record>
     </match>',
   # lint:endignore


### PR DESCRIPTION
Each event forwarded now also gets:
- vpc_id
- subnet_id
- private_ip (why not? correlation in client logs)
- ami_id (historical tracking)
- mac (its available and could be interesting if ami_ids ever get reused?)
- project (value of NUBIS_PROJECT)
- stack (value of NUBIS_STACK)
- purpose (value of NUBIS_PURPOSE)

Just makes for richer events in general

Fixes #502