### PR TITLE
Expose node-exporter as a Consul service

### DIFF
--- a/nubis/puppet/files/svc-node-exporter.json
+++ b/nubis/puppet/files/svc-node-exporter.json
@@ -1,0 +1,11 @@
+{
+  "service": {
+    "name": "node-exporter",
+    "port": 9100,
+    "check": {
+      "http": "http://localhost:9100/metrics",
+      "notes": "node_exporter is healthy and full of yummy metrics",
+      "interval": "60s"
+    }
+  }
+}

--- a/nubis/puppet/node_exporter.pp
+++ b/nubis/puppet/node_exporter.pp
@@ -58,3 +58,12 @@ case $::osfamily {
     fail("Unsupported OS for node_exporter ${::osfamily}")
   }
 }
+
+file { '/etc/consul/svc-node-exporter.json':
+  ensure  => file,
+  owner   => root,
+  group   => root,
+  mode    => '0644',
+  source  => 'puppet:///nubis/files/svc-node-exporter.json',
+  require => Class['consul'],
+}


### PR DESCRIPTION
This way, we have an actual service watching the health of our node_exporters

Prometheus will make use of that for its node discovery

Fixes #510