### PR TITLE
Correctly populate the NO_PROXY variable with IPs in our subnet.

### DIFF
--- a/nubis/puppet/files/nubis-network-ips
+++ b/nubis/puppet/files/nubis-network-ips
@@ -1,0 +1,19 @@
+#!/usr/bin/env perl
+use strict;
+
+use Sys::Hostname;
+use Socket;
+use NetAddr::IP;
+
+my $address = inet_ntoa( scalar gethostbyname( hostname() ) );
+
+my $mask = shift || "24";
+
+my $ip = NetAddr::IP->new("$address/$mask");
+
+my @ips;
+for my $addr ( @{ $ip->hostenumref } ) {
+    push @ips, $addr->addr;
+}
+
+print join ",", @ips;

--- a/nubis/puppet/files/profile.d_proxy.sh
+++ b/nubis/puppet/files/profile.d_proxy.sh
@@ -25,9 +25,11 @@ if [ -z "${PROXY}" ]; then
 fi
 
 if [ ! -z "${PROXY}" ]; then
+    # For now, we safely assume every instance we could care about are in a /24 network
+    NETWORK_IPS=$(/usr/local/bin/nubis-network-ips 24)
     export http_proxy="http://${PROXY}:3128/"
     export https_proxy="http://${PROXY}:3128/"
-    export no_proxy="localhost,127.0.0.1,.localdomain,10.0.0.0/8,169.254.169.254"
+    export no_proxy="localhost,127.0.0.1,.localdomain,169.254.169.254,$NETWORK_IPS"
     export HTTP_PROXY="$http_proxy"
     export HTTPS_PROXY="$https_proxy"
     export NO_PROXY="$no_proxy"

--- a/nubis/puppet/proxy.pp
+++ b/nubis/puppet/proxy.pp
@@ -8,3 +8,27 @@ file {
         group  => 'root',
         source => 'puppet:///nubis/files/profile.d_proxy.sh',
 }
+
+case $::osfamily {
+  'RedHat': {
+    package { 'perl-NetAddr-IP':
+      ensure => 'present',
+    }
+  }
+  'Debian': {
+    package { 'libnetaddr-ip-perl':
+      ensure => 'present',
+    }
+  }
+  default: {
+    fail("Unsupported OS for perl(NetAddr::IP) ${::osfamily}")
+  }
+}
+
+file { '/usr/local/bin/nubis-network-ips':
+  ensure => present,
+  mode   => '0755',
+  owner  => 'root',
+  group  => 'root',
+  source => 'puppet:///nubis/files/nubis-network-ips',
+}


### PR DESCRIPTION
Given how our networks are built, we safely assume we can just take our
network, and expand it to a /24 to get all IPs of our potential peers

Fixes #513