### PR TITLE
Create nubis-cron, prometheus wrapper for cronjobs

### DIFF
--- a/nubis/puppet/confd.pp
+++ b/nubis/puppet/confd.pp
@@ -8,7 +8,7 @@ class { 'confd':
 
 cron { 'confd-watchdog':
   ensure      => 'present',
-  command     => 'service confd start 1>/dev/null 2>/dev/null',
+  command     => 'nubis-cron confd-watchdog "service confd start 1>/dev/null 2>/dev/null"',
   hour        => '*',
   minute      => '*/11',
   user        => 'root',

--- a/nubis/puppet/cron.pp
+++ b/nubis/puppet/cron.pp
@@ -1,0 +1,7 @@
+file { '/usr/bin/nubis-cron':
+    ensure => file,
+    owner  => root,
+    group  => root,
+    mode   => '0755',
+    source => 'puppet:///nubis/files/nubis-cron',
+}

--- a/nubis/puppet/files/nubis-cron
+++ b/nubis/puppet/files/nubis-cron
@@ -31,3 +31,6 @@ nubis_cron_status{cronjob="$JOB"} $RV
 EOF
 
 mv -f "$METRICS" "$METRICS_PATH/nubis_cron_$JOB.prom"
+
+# Propagate exit code
+exit $RV

--- a/nubis/puppet/files/nubis-cron
+++ b/nubis/puppet/files/nubis-cron
@@ -1,0 +1,33 @@
+#!/bin/bash -l
+
+# Run a cronjob, and record start/end/status to prometheus metrics
+# usage:
+#  nubis-cron name-of-cron-job "commands to execute"
+
+cleanup () {
+ rm -f "$METRICS" 2>/dev/null
+}
+trap cleanup EXIT
+
+METRICS_PATH=/var/lib/node_exporter/metrics
+
+METRICS=$(mktemp)
+
+JOB=$1
+shift
+
+START=$(date +%s)
+
+bash -c "$@"
+
+RV=$?
+
+END=$(date +%s)
+
+cat <<EOF > $METRICS
+nubis_cron_end{cronjob="$JOB"} $END
+nubis_cron_start{cronjob="$JOB"} $START
+nubis_cron_status{cronjob="$JOB"} $RV
+EOF
+
+mv -f "$METRICS" "$METRICS_PATH/nubis_cron_$JOB.prom"

--- a/nubis/puppet/fluentd.pp
+++ b/nubis/puppet/fluentd.pp
@@ -194,7 +194,7 @@ if $osfamily == 'RedHat' {
 
 cron { 'fluent-watchdog':
   ensure      => 'present',
-  command     => 'service td-agent status 1>/dev/null || service td-agent start',
+  command     => 'nubis-cron fluent-watchdog "service td-agent status 1>/dev/null || service td-agent start"',
   hour        => '*',
   minute      => '*/11',
   user        => 'root',

--- a/nubis/puppet/node_exporter.pp
+++ b/nubis/puppet/node_exporter.pp
@@ -21,7 +21,7 @@ file { '/var/lib/node_exporter/metrics':
   ensure => directory,
   owner  => root,
   group  => root,
-  mode   => '0755',
+  mode   => '1777',
 }
 
 # make sure the services are disabled on boot, confd starts conditionnally later

--- a/nubis/puppet/nubis_users.pp
+++ b/nubis/puppet/nubis_users.pp
@@ -16,7 +16,7 @@ file { '/usr/local/bin/nubis-gen-puppet':
 
 cron { 'nubis-gen-puppet-watchdog':
   ensure      => present,
-  command     => '/usr/local/bin/nubis-gen-puppet',
+  command     => 'nubis-cron gen-puppet-watchdog /usr/local/bin/nubis-gen-puppet',
   hour        => '*',
   minute      => '*/30',
   user        => 'root',

--- a/nubis/puppet/taint.pp
+++ b/nubis/puppet/taint.pp
@@ -47,7 +47,7 @@ file {'/etc/ssh/sshrc':
 cron::hourly {
   'nubis-taint-reap':
     user    => 'root',
-    command => '/usr/local/sbin/nubis-taint-reap',
+    command => 'nubis-cron nubis-taint-reap /usr/local/sbin/nubis-taint-reap',
 }
 
 file { '/etc/consul/svc-tainted.json':


### PR DESCRIPTION
Use like this:

nubis-cron <name-of-job> some command to run

It will expose 3 metrics for the job

```
nubis_cron_start{cronjob="<name-of-job>"} 1481656261
nubis_cron_end{cronjob="<name-of-job>"} 1481656265
nubis_cron_status{cronjob="<name-of-job>"} 0
```

Fixes #459