### PR TITLE
Fix small *bad* tyop

### DIFF
--- a/nubis/puppet/files/nubis-cron
+++ b/nubis/puppet/files/nubis-cron
@@ -18,7 +18,7 @@ shift
 
 START=$(date +%s)
 
-bash -c "$@"
+bash -c "$*"
 
 RV=$?
 


### PR DESCRIPTION
bash -c "$@" turns into bash -c "command" "-argments"
bash -c "$*" turns into bash -c 'command -arguments'

Second option is correct