### PR TITLE
Cleanup /var/lib/node_exporter/metrics during image housekeeping

### DIFF
--- a/nubis/puppet/files/housekeeper
+++ b/nubis/puppet/files/housekeeper
@@ -19,6 +19,9 @@ sudo rm -f /var/spool/mail/*
 # Remove nubis cache
 sudo rm -f /var/cache/nubis/*
 
+# Remove metrics
+sudo rm -f /var/lib/node_exporter/metrics/*
+
 # Remove taintededness
 sudo rm -f /.tainted
 


### PR DESCRIPTION
Otherwise, it's possible we leave busted/invalid stuff behind

Fixes #567