### PR TITLE
Use $* as it should have been

### DIFF
--- a/nubis/puppet/files/purpose
+++ b/nubis/puppet/files/purpose
@@ -24,7 +24,7 @@ else
       exec "$@"
     fi
   else # We are not it
-    if [ -z "$@" ]; then
+    if [ -z "$*" ]; then
       # return failure for the pipe use case
       exit 1
     else


### PR DESCRIPTION
-z "$*" will work with multiple arguments, -z "$@" won't

Fixes #569