### PR TITLE
Upgrade nubis-travis to v1.3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ addons:
     - debian-sid
     packages:
     - shellcheck
+    - libssl1.0.0
 script:
 - nubis/travis/run-checks
 - nubis/travis/run-builds


### PR DESCRIPTION
This gets us newest nubis-builder with spot instances and no more aws cli

Fixes #593