### PR TITLE
Fix: Downgrade fluent-plugin-ec2-metadata to 0.0.15

### DIFF
--- a/nubis/puppet/fluentd.pp
+++ b/nubis/puppet/fluentd.pp
@@ -41,7 +41,7 @@ package { [$ruby_dev, 'make', 'gcc']:
 }
 
 fluentd::install_plugin { 'ec2-metadata':
-  ensure      => '0.0.16',
+  ensure      => '0.0.15',
   plugin_type => 'gem',
   plugin_name => 'fluent-plugin-ec2-metadata',
   require     => [


### PR DESCRIPTION
0.0.16 isn't on the gem repositories yet.

Un-Breaks #658