### PR TITLE
Make sure to inculde nubis_configuration at least once

### DIFF
--- a/nubis/puppet/confd.pp
+++ b/nubis/puppet/confd.pp
@@ -17,3 +17,9 @@ cron { 'confd-watchdog':
     'PATH=/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin:/opt/aws/bin',
   ],
 }
+
+# Generic
+include nubis_configuration
+nubis::configuration{ 'base':
+  format => 'sh',
+}


### PR DESCRIPTION
Otherwise, we don't get the needed /etc/nubis.d/confd startup script

Fixes #668