### PR TITLE
Move gen-puppet startup earlier in the boot process

### DIFF
--- a/nubis/puppet/nubis_users.pp
+++ b/nubis/puppet/nubis_users.pp
@@ -1,4 +1,4 @@
-file { '/etc/nubis.d/01-gen-puppet':
+file { '/etc/nubis.d/00-gen-puppet':
   ensure => file,
   owner  => root,
   group  => root,


### PR DESCRIPTION
Renamed to /etc/nubis.d/00-gen-puppet

Fixes #679