### PR TITLE
Upgrade to nubis-puppet-discovery v1.3.2 to silence a Puppet warning

### DIFF
--- a/nubis/Puppetfile
+++ b/nubis/Puppetfile
@@ -59,8 +59,8 @@ mod 'bhourigan/dnsmasq',
     :git => 'https://github.com/bhourigan/puppet-dnsmasq.git'
 
 mod 'nubis/nubis_discovery',
-    :git => 'https://github.com/Nubisproject/nubis-puppet-discovery.git',
-    :ref => 'v1.3.1'
+    :git => 'https://github.com/nubisproject/nubis-puppet-discovery.git',
+    :ref => 'v1.3.2'
 
 mod 'nubis/nubis_configuration',
     :git => 'https://github.com/Nubisproject/nubis-puppet-configuration.git',


### PR DESCRIPTION
Fixes #685