### PR TITLE
Upgrades node_exporter to v0.15.0

### DIFF
--- a/nubis/puppet/files/node_exporter.init
+++ b/nubis/puppet/files/node_exporter.init
@@ -20,7 +20,7 @@ export PATH
 
 name=node_exporter
 program="/usr/local/bin/$name"
-args="-collector.textfile.directory /var/lib/node_exporter/metrics"
+args="--collector.textfile.directory /var/lib/node_exporter/metrics --collector.nfs --collector.tcpstat --no-collector.wifi --no-collector.mdadm --no-collector.xfs --no-collector.zfs"
 pidfile=/var/run/$name.pid
 user=root
 group=root

--- a/nubis/puppet/files/node_exporter.upstart
+++ b/nubis/puppet/files/node_exporter.upstart
@@ -10,5 +10,5 @@ setgid root
 script
   exec >> /var/log/node_exporter.log
   exec 2>&1
-  exec /usr/local/bin/node_exporter -collector.textfile.directory /var/lib/node_exporter/metrics
+  exec /usr/local/bin/node_exporter --collector.textfile.directory /var/lib/node_exporter/metrics --collector.nfs --collector.tcpstat --no-collector.wifi --no-collector.mdadm --no-collector.xfs --no-collector.zfs
 end script

--- a/nubis/puppet/files/nubis-cron
+++ b/nubis/puppet/files/nubis-cron
@@ -26,9 +26,13 @@ END=$(date +%s)
 DURATION=$(( END - START ))
 
 cat <<EOF > "$METRICS"
+# HELP nubis_cron_end Metric created by nubis-cron
 nubis_cron_end{cronjob="$JOB"} $END
+# HELP nubis_cron_start Metric created by nubis-cron
 nubis_cron_start{cronjob="$JOB"} $START
+# HELP nubis_cron_duration Metric created by nubis-cron
 nubis_cron_duration{cronjob="$JOB"} $DURATION
+# HELP nubis_cron_status Metric created by nubis-cron
 nubis_cron_status{cronjob="$JOB"} $RV
 EOF
 

--- a/nubis/puppet/node_exporter.pp
+++ b/nubis/puppet/node_exporter.pp
@@ -1,5 +1,5 @@
-$node_exporter_version = '0.12.0'
-$node_exporter_url = "https://github.com/prometheus/node_exporter/releases/download/${node_exporter_version}/node_exporter-${node_exporter_version}.linux-amd64.tar.gz"
+$node_exporter_version = '0.15.0'
+$node_exporter_url = "https://github.com/prometheus/node_exporter/releases/download/v${node_exporter_version}/node_exporter-${node_exporter_version}.linux-amd64.tar.gz"
 
 notice ("Grabbing node_exporter ${node_exporter_version}")
 staging::file { "node_exporter.${node_exporter_version}.tar.gz":


### PR DESCRIPTION
Upgrades node exporter and remove metrics we don't care to scrape for. Includes a nubis-cron fix that since upgrading to v0.15.0 causes issues with it

PR fixes issue #737 #720 and #721 