### PR TITLE
/etc/duo/pam_duo.conf needs to be 0600 for duo to be happy

### DIFF
--- a/nubis/files/confd/conf.d/duo.toml
+++ b/nubis/files/confd/conf.d/duo.toml
@@ -6,4 +6,8 @@ keys = [
     "/config"
 ]
 
+uid = 0
+gid = 0
+mode = "0600"
+
 reload_cmd = "puppet apply /etc/duo/duo_sshd_config_runtime.pp"


### PR DESCRIPTION
Otherwise, we see messages like this and DUO is inoperating
```
sshd[3400]: /etc/duo/pam_duo.conf must be readable only by user 'root'
```

Fixes #748