### PR TITLE
Upgrade nubis-puppet-storage to v1.2.5

### DIFF
--- a/nubis/Puppetfile
+++ b/nubis/Puppetfile
@@ -87,7 +87,7 @@ mod 'nubis/nubis_configuration',
 
 mod 'nubis/nubis_storage',
     :git => 'https://github.com/nubisproject/nubis-puppet-storage.git',
-    :ref => 'v1.2.4'
+    :ref => 'v1.2.5'
 
 mod 'nubis/mig',
     :git => 'https://github.com/nubisproject/nubis-puppet-mig.git',


### PR DESCRIPTION
[Full Changelog](https://github.com/nubisproject/nubis-puppet-storage/compare/v1.2.4...v1.2.5)

**Closed issues:**

- EFS mount targets don't need the AZ prefix anymore [\#46](https://github.com/nubisproject/nubis-puppet-storage/issues/46)
- Generate Prometheus metric exposing the EFS fsid we are using [\#45](https://github.com/nubisproject/nubis-puppet-storage/issues/45)
- Remove hardcoded value [\#36](https://github.com/nubisproject/nubis-puppet-storage/issues/36)

**Merged pull requests:**

- EFS mount targets don't need AZ prefix anymore [\#49](https://github.com/nubisproject/nubis-puppet-storage/pull/49) ([gozer](https://github.com/gozer))
- Create Prometheus metric exposing the EFS id [\#48](https://github.com/nubisproject/nubis-puppet-storage/pull/48) ([gozer](https://github.com/gozer))

Fixes #768