### PR TITLE
Handle swap creation for instances at boot time

### DIFF
--- a/nubis/files/swap
+++ b/nubis/files/swap
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Look at supplied value
+NUBIS_SWAP_SIZE_MEG=$(nubis-metadata NUBIS_SWAP_SIZE_MEG)
+
+# Use sane default otherwise
+if [ -z "$NUBIS_SWAP_SIZE_MEG" ]; then
+  NUBIS_SWAP_SIZE_MEG=512
+fi
+
+# Only disabled if explicitely set to 0
+if [ "$NUBIS_SWAP_SIZE_MEG" -gt "0" ]; then
+  SWAP_FILE=/var/swap.img
+
+  echo "Making $NUBIS_SWAP_SIZE_MEG Mb of swap in $SWAP_FILE"
+  dd if=/dev/zero of=$SWAP_FILE bs="1M" count="$NUBIS_SWAP_SIZE_MEG"
+  chmod 600 $SWAP_FILE
+  mkswap $SWAP_FILE
+  swapon $SWAP_FILE
+fi

--- a/nubis/puppet/swap.pp
+++ b/nubis/puppet/swap.pp
@@ -1,0 +1,14 @@
+sysctl { 'vm.swappiness':
+  value => 10,
+}
+
+file { '/etc/nubis.d/0-swap':
+  ensure  => 'present',
+  mode    => '0755',
+  owner   => 'root',
+  group   => 'root',
+  source  => 'puppet:///nubis/files/swap',
+  require => [
+    File['/etc/nubis.d'],
+  ]
+}


### PR DESCRIPTION
Can be configured in user-data with NUBIS_SWAP_SIZE_MEG.
Defaults to 512 Megs
Disable completely by setting it to 0

Also, tune down swapiness to 10

Fixes #778