### PR TITLE
Pointing hiera config to new location

### DIFF
--- a/nubis/files/nubis-gen-puppet
+++ b/nubis/files/nubis-gen-puppet
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-if [ -f '/etc/puppet/yaml/nubis_users/common.yaml' ]; then
+if [ -f '/etc/puppetlabs/puppet/yaml/nubis_users/common.yaml' ]; then
     # ensure that puppet apply on a periodic basis
     # in case someone nukes a home directory it will get regenerated
-    puppet apply --hiera_config /etc/puppet/hiera.yaml -e 'include nubis_users'
+    puppet apply --hiera_config /etc/puppetlabs/puppet/hiera.yaml -e 'include nubis_users'
     RV=$?
     exit "${RV}"
 fi


### PR DESCRIPTION
This fix needs the following resolved

- nubisproject/nubis-puppet-nubis_users#40
- nubisproject/nubis-puppet-nubis_users#41

Once those are resolved there needs to be a release for that puppet module and then we need to bump version number in Puppetfile