### PR TITLE
Revert "New MIG agent release"

### DIFF
--- a/nubis/puppet/mig.pp
+++ b/nubis/puppet/mig.pp
@@ -6,6 +6,6 @@ if $osfamily == 'redhat' {
 }
 
 class {'mig':
-  version => '20180803',
-  build   => '0.e8eb90a'
+  version => '20160715',
+  build   => '0.a06734a'
 }


### PR DESCRIPTION
Reverts nubisproject/nubis-base#883

This is causing builds to fail with the following error:

Error: 'wget --verbose --output-document="/tmp/mig.rpm" "https://s3.amazonaws.com/mozopsecrepo2/mig-public/it-nubis/mig-agent-20180803_0.e8eb90a.prod-1.x86_64.rpm"' returned 8 instead of one of [0]

When I attempt to view the file directly I get:
Error><Code>AccessDenied</Code><Message>Access Denied</Message><RequestId>8C5B0637D80186C3</RequestId><HostId>XIVacbfClnhCPz5q4S2EQsC4T9DaUjW4BSA9LqSDJkuFZrNrRWzrHBs7M9rJcAOO9grhkcOYcMk=</HostId></Error>

Let me know when you have fixed this issue and I will re-merge this build. For now I am trying to get a patch release out the door and this issue is blocking that release.